### PR TITLE
build: ci.yml and release.yml should reference .nvmrc file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version-file: '.nvmrc'
       - run: npm ci
       - run: npm test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setting composite action runtime
         uses: actions/setup-node@v3.1.0
         with:
-          node-version: 12
+          node-version-file: '.nvmrc'
 
       - uses: nearform/optic-release-automation-action@main
         with:


### PR DESCRIPTION
Workflows in cy.yml and release.yml were on older versions of node - this PR adds a reference to draw the version from the .nvmrc file