### PR TITLE
feat: Add an output containing the issue numbers of the linked issues

### DIFF
--- a/__mocks__/@actions/github.js
+++ b/__mocks__/@actions/github.js
@@ -19,7 +19,21 @@ module.exports = {
               pullRequest: {
                 id: "fake-pr-id",
                 closingIssuesReferences: {
-                  totalCount: 1,
+                  totalCount: 2,
+                  nodes: [
+                    {
+                      number: 12345,
+                      repository: {
+                        nameWithOwner: "test/repo",
+                      },
+                    },
+                    {
+                      number: 456,
+                      repository: {
+                        nameWithOwner: "another/repository",
+                      },
+                    },
+                  ],
                 },
               },
             },

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,8 @@ inputs:
 outputs:
   linked_issues_count:
     description: 'The total number of issues linked to your pull request.'
+  issues:
+    description: 'A stringified array containing the numbers of the linked issues, of the form ["some/repo#123", "another/repository#456"]'
 
 runs:
   using: 'node16'

--- a/src/action.js
+++ b/src/action.js
@@ -52,6 +52,9 @@ async function run() {
 
     const pullRequest = data?.repository?.pullRequest;
     const linkedIssuesCount = pullRequest?.closingIssuesReferences?.totalCount;
+    const issues = (pullRequest?.closingIssuesReferences?.nodes || []).map(
+      (node) => `${node.repository.nameWithOwner}#${node.number}`
+    );
 
     const linkedIssuesComments = await getPrComments({
       octokit,
@@ -61,6 +64,7 @@ async function run() {
     });
 
     core.setOutput("linked_issues_count", linkedIssuesCount);
+    core.setOutput("issues", issues);
 
     if (!linkedIssuesCount) {
       const prId = pullRequest?.id;

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -22,13 +22,13 @@ it("should fail when called with an unsupported event type", async () => {
 });
 
 test.each([
-  ["pull_request", 1],
-  ["pull_request_target", 1],
+  ["pull_request", 2, ["test/repo#12345", "another/repository#456"]],
+  ["pull_request_target", 2, ["test/repo#12345", "another/repository#456"]],
 ])(
-  "should return the number of linked issues and delete previous comments from linked_issues action while listening %p event",
-  async (eventName, result) => {
+  "should return the number of linked issues and their repos and delete previous comments from linked_issues action while listening %p event",
+  async (eventName, n, issueArray) => {
     // eslint-disable-next-line
-  github.context = {
+    github.context = {
       eventName,
       payload: {
         action: "opened",
@@ -44,8 +44,9 @@ test.each([
 
     await run();
 
-    expect(core.setOutput).toHaveBeenCalledWith("linked_issues_count", result);
-    expect(core.debug).toHaveBeenCalledWith(`${result} Comment(s) deleted.`);
+    expect(core.setOutput).toHaveBeenNthCalledWith(1, "linked_issues_count", n);
+    expect(core.setOutput).toHaveBeenNthCalledWith(2, "issues", issueArray);
+    expect(core.debug).toHaveBeenCalledWith(`1 Comment(s) deleted.`);
   }
 );
 
@@ -59,7 +60,7 @@ test.each([["pull_request"], ["pull_request_target"]])(
     }
   }`.replace(/\s/g, "");
     // eslint-disable-next-line
-  github.context = {
+    github.context = {
       eventName,
       payload: {
         action: "opened",
@@ -129,7 +130,7 @@ test.each([["pull_request"], ["pull_request_target"]])(
     }
   }`.replace(/\s/g, "");
     // eslint-disable-next-line
-  github.context = {
+    github.context = {
       eventName,
       payload: {
         action: "opened",
@@ -194,7 +195,7 @@ test.each([["pull_request"], ["pull_request_target"]])(
   "should not add new comment when core input comment is not defined while listening %p event",
   async (eventName) => {
     // eslint-disable-next-line
-  github.context = {
+    github.context = {
       eventName,
       payload: {
         action: "opened",
@@ -209,7 +210,7 @@ test.each([["pull_request"], ["pull_request_target"]])(
     };
 
     // eslint-disable-next-line
-  github.getOctokit = jest.fn(() => {
+    github.getOctokit = jest.fn(() => {
       return {
         paginate: jest.fn(),
         graphql: jest.fn(() => {
@@ -230,7 +231,7 @@ test.each([["pull_request"], ["pull_request_target"]])(
     });
 
     // eslint-disable-next-line
-  core.getInput.mockReturnValue("");
+    core.getInput.mockReturnValue("");
 
     await run();
 

--- a/src/util.js
+++ b/src/util.js
@@ -67,8 +67,14 @@ export function getLinkedIssues({ octokit, prNumber, repoOwner, repoName }) {
       repository(owner: $owner, name: $name) {
         pullRequest(number: $number) {
           id
-          closingIssuesReferences {
+          closingIssuesReferences(first: 100) {
             totalCount
+            nodes {
+              number
+              repository {
+                nameWithOwner
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
For my use-case, I'd like to see if the linked issues are tied to a certain repository. This PR adds an `output` that contains an array of the issues' numbers, so you can string search to find certain repository names.

partially resolves cloudflare/wrangler2#1968